### PR TITLE
[bug-fix] - correcao de acesso a variaveis de estado

### DIFF
--- a/src/store/provider/actions.js
+++ b/src/store/provider/actions.js
@@ -20,12 +20,13 @@ export const fetchProviders = () => {
         name,
       });
     });
+
     dispatch(receiveProviders(providers));
   };
 };
 
 export const findProviderById = id => {
-  const providers = store.getState().appointment.providers;
+  const providers = store.getState().provider.providers;
 
   const provider = providers?.find(provider => provider.id === id);
 


### PR DESCRIPTION
Durante a refatoração de módulos acabei esquecendo de refatorar o nome das variáveis de acesso ao estado _redux_ também.